### PR TITLE
feat: expose GenerateRandomBase64 helper in auth package

### DIFF
--- a/auth/crypto.go
+++ b/auth/crypto.go
@@ -34,6 +34,15 @@ func GenerateRandomHex(n int) (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
+// GenerateRandomBase64 generates n random bytes and returns them as URL-safe base64.
+func GenerateRandomBase64(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate random bytes: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
 // MustGenerateDummyBcryptHash generates a bcrypt hash for timing-safe comparisons
 // when a user is not found.
 func MustGenerateDummyBcryptHash(secret string) []byte {

--- a/handler/oidc.go
+++ b/handler/oidc.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
 	"fmt"
@@ -60,11 +59,7 @@ func NewOIDCHandler(ctx context.Context, users auth.UserStore, jwt *auth.JWTMana
 }
 
 func generateOIDCState() (string, error) {
-	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return base64.URLEncoding.EncodeToString(b), nil
+	return auth.GenerateRandomBase64(32)
 }
 
 // Login redirects to the OIDC provider.


### PR DESCRIPTION
## Summary
- Adds `auth.GenerateRandomBase64(n)` as a public helper that generates `n` random bytes via `crypto/rand` and returns URL-safe base64 (no padding). This mirrors the existing `GenerateRandomHex` helper.
- Updates `handler/oidc.go` to use the new helper for OIDC state generation instead of inlining its own crypto/rand + base64 logic.
- Library consumers can now generate secure random base64 tokens without reimplementing the pattern themselves.

## Test plan
- [x] `go build ./...` passes
- [ ] Verify OIDC login/callback flow still works end-to-end (state parameter is opaque and compared by exact equality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)