### PR TITLE
docs: clarify SecretEncrypter internals; add Claims struct and AdminC…

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), auth.BcryptCo
 
 #### SecretEncrypter (AES-256-GCM)
 
-`SecretEncrypter` is safe for concurrent use. Both the AES block cipher and the `cipher.AEAD` (GCM) instance are created once at construction time and reused across all `Encrypt` and `Decrypt` calls. Go's AES-GCM implementation does not share mutable state between concurrent `Seal`/`Open` invocations, so a single cached instance is safe. The raw derived key is zeroed immediately after the cipher is created.
+`SecretEncrypter` is safe for concurrent use. The `cipher.AEAD` (AES-256-GCM, which wraps the AES block cipher internally) is created once at construction time and stored as the only field; it is reused across all `Encrypt` and `Decrypt` calls. Go's AES-GCM implementation does not share mutable state between concurrent `Seal`/`Open` invocations, so a single cached instance is safe. The raw derived key is zeroed immediately after the cipher is created.
 
 ```go
 enc, err := jwtMgr.NewSecretEncrypter()

--- a/docs/auth/crypto.md
+++ b/docs/auth/crypto.md
@@ -22,7 +22,7 @@ passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), auth.BcryptCo
 
 ## SecretEncrypter (AES-256-GCM)
 
-`SecretEncrypter` is safe for concurrent use. The AES block cipher and the `cipher.AEAD` (GCM) are both created once at construction time and reused across all `Encrypt` and `Decrypt` calls. Go's AES-GCM implementation does not store per-call mutable state — each `Seal`/`Open` call operates on the nonce passed to it — so sharing the instance across goroutines is safe. The raw derived key is zeroed immediately after the cipher is created.
+`SecretEncrypter` is safe for concurrent use. The `cipher.AEAD` (AES-256-GCM, which wraps the AES block cipher internally) is created once at construction time and stored as the only field; it is reused across all `Encrypt` and `Decrypt` calls. Go's AES-GCM implementation does not store per-call mutable state — each `Seal`/`Open` call operates on the nonce passed to it — so sharing the instance across goroutines is safe. The raw derived key is zeroed immediately after the cipher is created.
 
 ```go
 enc, err := jwtMgr.NewSecretEncrypter()

--- a/docs/auth/jwt.md
+++ b/docs/auth/jwt.md
@@ -27,7 +27,16 @@ token, err := jwtMgr.CreateTokenWithSession(ctx, userID, sessionID)
 
 ```go
 claims, err := jwtMgr.ValidateToken(ctx, tokenString)
-// claims.UserID contains the subject; claims.ID contains the session ID (jti)
+// claims.UserID contains the subject (sub); claims.ID contains the session ID (jti)
+```
+
+`Claims` embeds `jwt.RegisteredClaims` and exposes one additional field:
+
+```go
+type Claims struct {
+    UserID string `json:"sub"` // authenticated user ID
+    jwt.RegisteredClaims       // ID (jti), ExpiresAt, IssuedAt, Issuer, Audience, …
+}
 ```
 
 ### Parsing without time checks

--- a/docs/auth/middleware.md
+++ b/docs/auth/middleware.md
@@ -29,6 +29,16 @@ Require admin status (checked via `AdminChecker.IsAdmin`, cached 5 seconds per u
 r.Use(auth.AdminMiddleware(jwtMgr, userStore, cfg, apiKeyStore))
 ```
 
+`AdminChecker` is a single-method interface:
+
+```go
+type AdminChecker interface {
+    IsAdmin(ctx context.Context, userID string) (bool, error)
+}
+```
+
+`auth.UserStore` satisfies `AdminChecker` directly. To derive an `AdminChecker` from a `RoleChecker`, use `auth.NewAdminCheckerFromRoleChecker` (see [RBAC](rbac.md)).
+
 The internal admin cache has a **4,096-entry FIFO size cap** and sweeps expired entries at most once per minute during writes. Oldest-inserted entries are evicted first when the cap is reached.
 
 ## Role / permission middleware


### PR DESCRIPTION
…hecker interface

- docs/auth/crypto.md, README.md: Clarify that SecretEncrypter stores only the cipher.AEAD (GCM) as its single field. The previous text said 'the AES block cipher and the cipher.AEAD are both created once', which implied two separate stored objects. The block cipher is embedded within GCM; only the AEAD is retained. Matches auth/crypto.go: SecretEncrypter{gcm: gcm}.

- docs/auth/jwt.md: Add the Claims struct definition so developers can see all available fields (UserID/sub + jwt.RegisteredClaims incl. ID/jti, ExpiresAt, IssuedAt, Issuer, Audience) without reading the source.

- docs/auth/middleware.md: Add explicit AdminChecker interface definition and note that auth.UserStore satisfies it directly, with a pointer to auth.NewAdminCheckerFromRoleChecker for RBAC-based setups.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a documentation-only PR that corrects and expands three areas: (1) clarifies that `SecretEncrypter` stores only the `cipher.AEAD` as its single field (not both the block cipher and the AEAD), (2) adds the `Claims` struct definition to `jwt.md`, and (3) exposes the `AdminChecker` interface definition in `middleware.md`. All added snippets were verified against the source and are accurate.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; documentation-only changes with no runtime impact and one minor in-source doc inconsistency.

All changes are prose/doc clarifications with no logic modifications. The only finding is a P2 inconsistency between the updated external docs and the still-old Go doc comment in crypto.go.

auth/crypto.go — in-source doc comment was not updated to match the external docs change.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Accurate prose update: clarifies that SecretEncrypter stores only the cipher.AEAD as its single field, matching crypto.go. |
| docs/auth/crypto.md | Same single-sentence clarification as README.md; wording matches the struct definition in crypto.go. |
| docs/auth/jwt.md | Adds Claims struct snippet that exactly mirrors auth/jwt.go lines 17–21; fields, JSON tags, and embedded type are all correct. |
| docs/auth/middleware.md | Adds AdminChecker interface definition matching middleware.go lines 175–178; UserStore satisfaction claim and NewAdminCheckerFromRoleChecker reference are both accurate. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AdminMiddleware] --> B{AdminChecker}
    B -->|UserStore directly| C[UserStore.IsAdmin]
    B -->|RBAC adapter| D[NewAdminCheckerFromRoleChecker]
    D --> E[RoleChecker.HasRole with RoleAdmin]
    C --> F[cachingAdminChecker\n4096-entry FIFO, 5s TTL]
    D --> F
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `auth/crypto.go`, line 57-58 ([link](https://github.com/amalgamated-tools/goauth/blob/37256b04649370ed8f3ee19bff5cb22362193cf6/auth/crypto.go#L57-L58)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **In-source Go doc comment still uses the old phrasing**

   The external docs (`README.md`, `docs/auth/crypto.md`) were updated to say only the `cipher.AEAD` is stored, but the Go doc comment on `SecretEncrypter` still reads "The AES block cipher and the `cipher.AEAD` returned by `cipher.NewGCM` are created once at construction time" — the same wording the PR is explicitly correcting. Keeping the old phrasing in-source creates an inconsistency for anyone reading the godoc output.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: auth/crypto.go
   Line: 57-58

   Comment:
   **In-source Go doc comment still uses the old phrasing**

   The external docs (`README.md`, `docs/auth/crypto.md`) were updated to say only the `cipher.AEAD` is stored, but the Go doc comment on `SecretEncrypter` still reads "The AES block cipher and the `cipher.AEAD` returned by `cipher.NewGCM` are created once at construction time" — the same wording the PR is explicitly correcting. Keeping the old phrasing in-source creates an inconsistency for anyone reading the godoc output.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amalgamated-tools%2Fgoauth%22%20on%20the%20existing%20branch%20%22docs%2Ffix-secretencrypter-and-claims-5a415fedeffd39f5%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Ffix-secretencrypter-and-claims-5a415fedeffd39f5%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20auth%2Fcrypto.go%0ALine%3A%2057-58%0A%0AComment%3A%0A**In-source%20Go%20doc%20comment%20still%20uses%20the%20old%20phrasing**%0A%0AThe%20external%20docs%20%28%60README.md%60%2C%20%60docs%2Fauth%2Fcrypto.md%60%29%20were%20updated%20to%20say%20only%20the%20%60cipher.AEAD%60%20is%20stored%2C%20but%20the%20Go%20doc%20comment%20on%20%60SecretEncrypter%60%20still%20reads%20%22The%20AES%20block%20cipher%20and%20the%20%60cipher.AEAD%60%20returned%20by%20%60cipher.NewGCM%60%20are%20created%20once%20at%20construction%20time%22%20%E2%80%94%20the%20same%20wording%20the%20PR%20is%20explicitly%20correcting.%20Keeping%20the%20old%20phrasing%20in-source%20creates%20an%20inconsistency%20for%20anyone%20reading%20the%20godoc%20output.%0A%0A%60%60%60suggestion%0A%2F%2F%20SecretEncrypter%20encrypts%20and%20decrypts%20sensitive%20values%20using%20AES-256-GCM.%0A%2F%2F%20The%20cipher.AEAD%20%28AES-256-GCM%2C%20which%20wraps%20the%20AES%20block%20cipher%20internally%29%0A%2F%2F%20is%20created%20once%20at%20construction%20time%20and%20stored%20as%20the%20only%20field%3B%20it%20is%0A%2F%2F%20reused%20across%20Encrypt%2FDecrypt%20calls.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amalgamated-tools%2Fgoauth%22%20on%20the%20existing%20branch%20%22docs%2Ffix-secretencrypter-and-claims-5a415fedeffd39f5%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Ffix-secretencrypter-and-claims-5a415fedeffd39f5%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aauth%2Fcrypto.go%3A57-58%0A**In-source%20Go%20doc%20comment%20still%20uses%20the%20old%20phrasing**%0A%0AThe%20external%20docs%20%28%60README.md%60%2C%20%60docs%2Fauth%2Fcrypto.md%60%29%20were%20updated%20to%20say%20only%20the%20%60cipher.AEAD%60%20is%20stored%2C%20but%20the%20Go%20doc%20comment%20on%20%60SecretEncrypter%60%20still%20reads%20%22The%20AES%20block%20cipher%20and%20the%20%60cipher.AEAD%60%20returned%20by%20%60cipher.NewGCM%60%20are%20created%20once%20at%20construction%20time%22%20%E2%80%94%20the%20same%20wording%20the%20PR%20is%20explicitly%20correcting.%20Keeping%20the%20old%20phrasing%20in-source%20creates%20an%20inconsistency%20for%20anyone%20reading%20the%20godoc%20output.%0A%0A%60%60%60suggestion%0A%2F%2F%20SecretEncrypter%20encrypts%20and%20decrypts%20sensitive%20values%20using%20AES-256-GCM.%0A%2F%2F%20The%20cipher.AEAD%20%28AES-256-GCM%2C%20which%20wraps%20the%20AES%20block%20cipher%20internally%29%0A%2F%2F%20is%20created%20once%20at%20construction%20time%20and%20stored%20as%20the%20only%20field%3B%20it%20is%0A%2F%2F%20reused%20across%20Encrypt%2FDecrypt%20calls.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: auth/crypto.go
Line: 57-58

Comment:
**In-source Go doc comment still uses the old phrasing**

The external docs (`README.md`, `docs/auth/crypto.md`) were updated to say only the `cipher.AEAD` is stored, but the Go doc comment on `SecretEncrypter` still reads "The AES block cipher and the `cipher.AEAD` returned by `cipher.NewGCM` are created once at construction time" — the same wording the PR is explicitly correcting. Keeping the old phrasing in-source creates an inconsistency for anyone reading the godoc output.

```suggestion
// SecretEncrypter encrypts and decrypts sensitive values using AES-256-GCM.
// The cipher.AEAD (AES-256-GCM, which wraps the AES block cipher internally)
// is created once at construction time and stored as the only field; it is
// reused across Encrypt/Decrypt calls.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify SecretEncrypter internals;..."](https://github.com/amalgamated-tools/goauth/commit/37256b04649370ed8f3ee19bff5cb22362193cf6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30242526)</sub>

<!-- /greptile_comment -->