### PR TITLE
chore: bump deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0
-	github.com/go-webauthn/webauthn v0.16.4
+	github.com/go-webauthn/webauthn v0.17.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.50.0
@@ -22,7 +22,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/tinylib/msgp v1.6.3 // indirect
+	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
-github.com/go-webauthn/webauthn v0.16.4 h1:R9jqR/cYZa7hRquFF7Za/8qoH/K/TIs1/Q/4CyGN+1Q=
-github.com/go-webauthn/webauthn v0.16.4/go.mod h1:SU2ljAgToTV/YLPI0C05QS4qn+e04WpB5g1RMfcZfS4=
+github.com/go-webauthn/webauthn v0.17.0 h1:8tFdaByIF7EgAg0W849Wt5q+213f1drsV2ggC0t80wM=
+github.com/go-webauthn/webauthn v0.17.0/go.mod h1:mQC6L0lZ5Kiu35G70zeB2WnrW4+vbHjR8Koq4HdVaMg=
 github.com/go-webauthn/x v0.2.3 h1:8oArS+Rc1SWFLXhE17KZNx258Z4kUSyaDgsSncCO5RA=
 github.com/go-webauthn/x v0.2.3/go.mod h1:tM04GF3V6VYq79AZMl7vbj4q6pz9r7L2criWRzbWhPk=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
@@ -36,8 +36,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
-github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
+github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=
+github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=


### PR DESCRIPTION
This pull request updates two dependencies in the `go.mod` file to their latest patch and minor versions. These are routine maintenance changes to keep dependencies up to date.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps two dependencies: `github.com/go-webauthn/webauthn` from `v0.16.4` to `v0.17.0` (minor version) and `github.com/tinylib/msgp` from `v1.6.3` to `v1.6.4` (patch). The `go.sum` file is updated accordingly with new hashes for both packages.

The `go-webauthn/webauthn` v0.17.0 release adds new opt-in features (`FilteringConfig`, `ValidateFilteredCredential`) and a backward-compatible `Credential.UnmarshalJSON` migration; no breaking changes are noted in the library's BREAKING.md for this version. The `msgp` bump is a routine patch.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — routine dependency bumps with no breaking changes.

Both version bumps are well-scoped: the msgp bump is a patch, and go-webauthn v0.17.0 adds only additive features and a backward-compatible JSON migration with no entries in the library's BREAKING.md. No logic changes, no custom-rule violations.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| go.mod | Bumps go-webauthn/webauthn v0.16.4→v0.17.0 (minor, additive only) and tinylib/msgp v1.6.3→v1.6.4 (patch); no breaking changes identified. |
| go.sum | Hash entries updated to match the two bumped dependencies; all other checksums remain unchanged. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[go.mod / go.sum bump] --> B[go-webauthn/webauthn]
    A --> C[tinylib/msgp]
    B --> D[v0.16.4 → v0.17.0\nMinor version bump]
    C --> E[v1.6.3 → v1.6.4\nPatch version bump]
    D --> F[New additive features\nFilteringConfig\nValidateFilteredCredential\nCredential.UnmarshalJSON migration]
    D --> G[No BREAKING.md entry\nfor v0.17.0]
    E --> H[Patch-level fix\nNo breaking changes]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump deps"](https://github.com/amalgamated-tools/goauth/commit/6f06c323eb7e19ba69046ee72d5d2778194d1be4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30572684)</sub>

<!-- /greptile_comment -->