### PR TITLE
docs: fix README feature list and RefreshCookieName comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # goauth
 
-**goauth** is a router-agnostic Go library that provides complete authentication infrastructure for web applications. It covers JWT session management, email/password auth, OIDC (SSO) login, WebAuthn passkeys, API key authentication, magic link (passwordless) login, TOTP/MFA, email verification, password reset, RBAC, rate limiting, AES-256-GCM encryption, and SMTP email delivery.
+**goauth** is a router-agnostic Go library that provides complete authentication infrastructure for web applications. It covers JWT session management, email/password auth, OIDC (SSO) login, generic OAuth2 login (GitHub, Discord, Slack, and any custom provider), WebAuthn passkeys, API key authentication, magic link (passwordless) login, TOTP/MFA, email verification, password reset, RBAC, rate limiting, AES-256-GCM encryption, and SMTP email delivery.
 
 ## Packages
 
@@ -38,7 +38,7 @@ authHandler := &handler.AuthHandler{
     SecureCookies:     true,
     Sessions:          sessionStore,      // enables server-side sessions + refresh tokens
     RefreshTokenTTL:   7 * 24 * time.Hour,
-    RefreshCookieName: "refresh",         // optional: deliver refresh token via cookie
+    RefreshCookieName: "refresh",         // required when Sessions is set
 }
 apiKeyHandler := &handler.APIKeyHandler{
     APIKeys:      apiKeyStore,


### PR DESCRIPTION
- Add 'generic OAuth2 login (GitHub, Discord, Slack, and any custom provider)' to the intro feature list; the OAuth2Handler and built-in providers (GitHubProvider, GoogleOAuth2Provider) exist in the codebase but were absent from the README description (present in docs/index.md)
- Correct the RefreshCookieName quick-start comment from 'optional' to 'required when Sessions is set'; AuthHandler.Validate() enforces this constraint and returns an error when Sessions is non-nil but RefreshCookieName is empty

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes two documentation-only corrections to `README.md`: it adds generic OAuth2 login to the intro feature list (matching the existing `OAuth2Handler` and built-in providers already present in the codebase), and updates the `RefreshCookieName` quick-start comment from \"optional\" to \"required when Sessions is set\" (matching `AuthHandler.Validate()` enforcement and the `auth.go` struct comment).

- The OAuth2 addition accurately reflects `handler/oauth2.go` and the built-in `GitHubProvider`/`GoogleOAuth2Provider` implementations.
- The `RefreshCookieName` correction aligns the quick-start comment with actual runtime behaviour, but the equivalent comment in the detailed `AuthHandler` reference block (line 520) still reads `// optional` and was not updated in this PR.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — documentation-only change with no runtime impact.

Both changes are accurate relative to the source code. The only remaining gap is a parallel "optional" label for RefreshCookieName in the detailed AuthHandler reference block that this PR did not touch, leaving the README internally inconsistent on that point.

README.md line 520 — the detailed AuthHandler struct example still labels RefreshCookieName as optional.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Two doc-only changes: adds generic OAuth2 to the intro feature list (accurate, matching handler/oauth2.go), and corrects the RefreshCookieName quick-start comment from "optional" to "required when Sessions is set" (matches AuthHandler.Validate() enforcement). A parallel occurrence of the old "optional" label remains in the detailed AuthHandler reference block at line 520. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AuthHandler configured] --> B{Sessions set?}
    B -- No --> C[RefreshCookieName optional\nRefresh tokens disabled]
    B -- Yes --> D{RefreshCookieName set?}
    D -- No --> E[Validate returns error\ntoken issuance HTTP 500]
    D -- Yes --> F[Refresh token issued\nstored in HttpOnly cookie]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `README.md`, line 520 ([link](https://github.com/amalgamated-tools/goauth/blob/e999fcd8eea62f5626a7abfece160e13adff4085/README.md#L520)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The `RefreshCookieName` field is still labelled `// optional` in the detailed `AuthHandler` reference block further down in the README. This is now inconsistent with the quick-start comment fixed in this PR and with the `auth.go` source comment ("Required when Sessions is non-nil"). `AuthHandler.Validate()` returns an error when `Sessions` is set and `RefreshCookieName` is empty, so calling it optional is misleading.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: README.md
   Line: 520

   Comment:
   The `RefreshCookieName` field is still labelled `// optional` in the detailed `AuthHandler` reference block further down in the README. This is now inconsistent with the quick-start comment fixed in this PR and with the `auth.go` source comment ("Required when Sessions is non-nil"). `AuthHandler.Validate()` returns an error when `Sessions` is set and `RefreshCookieName` is empty, so calling it optional is misleading.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amalgamated-tools%2Fgoauth%22%20on%20the%20existing%20branch%20%22docs%2Ffix-readme-oauth2-and-refresh-cookie-06709c5f1aa5865f%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Ffix-readme-oauth2-and-refresh-cookie-06709c5f1aa5865f%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20README.md%0ALine%3A%20520%0A%0AComment%3A%0AThe%20%60RefreshCookieName%60%20field%20is%20still%20labelled%20%60%2F%2F%20optional%60%20in%20the%20detailed%20%60AuthHandler%60%20reference%20block%20further%20down%20in%20the%20README.%20This%20is%20now%20inconsistent%20with%20the%20quick-start%20comment%20fixed%20in%20this%20PR%20and%20with%20the%20%60auth.go%60%20source%20comment%20%28%22Required%20when%20Sessions%20is%20non-nil%22%29.%20%60AuthHandler.Validate%28%29%60%20returns%20an%20error%20when%20%60Sessions%60%20is%20set%20and%20%60RefreshCookieName%60%20is%20empty%2C%20so%20calling%20it%20optional%20is%20misleading.%0A%0A%60%60%60suggestion%0A%20%20%20%20RefreshCookieName%3A%20%22refresh%22%2C%20%20%2F%2F%20required%20when%20Sessions%20is%20set%3B%20stores%20refresh%20token%20in%20an%20HttpOnly%20cookie%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amalgamated-tools%2Fgoauth%22%20on%20the%20existing%20branch%20%22docs%2Ffix-readme-oauth2-and-refresh-cookie-06709c5f1aa5865f%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Ffix-readme-oauth2-and-refresh-cookie-06709c5f1aa5865f%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A520%0AThe%20%60RefreshCookieName%60%20field%20is%20still%20labelled%20%60%2F%2F%20optional%60%20in%20the%20detailed%20%60AuthHandler%60%20reference%20block%20further%20down%20in%20the%20README.%20This%20is%20now%20inconsistent%20with%20the%20quick-start%20comment%20fixed%20in%20this%20PR%20and%20with%20the%20%60auth.go%60%20source%20comment%20%28%22Required%20when%20Sessions%20is%20non-nil%22%29.%20%60AuthHandler.Validate%28%29%60%20returns%20an%20error%20when%20%60Sessions%60%20is%20set%20and%20%60RefreshCookieName%60%20is%20empty%2C%20so%20calling%20it%20optional%20is%20misleading.%0A%0A%60%60%60suggestion%0A%20%20%20%20RefreshCookieName%3A%20%22refresh%22%2C%20%20%2F%2F%20required%20when%20Sessions%20is%20set%3B%20stores%20refresh%20token%20in%20an%20HttpOnly%20cookie%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
README.md:520
The `RefreshCookieName` field is still labelled `// optional` in the detailed `AuthHandler` reference block further down in the README. This is now inconsistent with the quick-start comment fixed in this PR and with the `auth.go` source comment ("Required when Sessions is non-nil"). `AuthHandler.Validate()` returns an error when `Sessions` is set and `RefreshCookieName` is empty, so calling it optional is misleading.

```suggestion
    RefreshCookieName: "refresh",  // required when Sessions is set; stores refresh token in an HttpOnly cookie
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix README feature list and Refres..."](https://github.com/amalgamated-tools/goauth/commit/e999fcd8eea62f5626a7abfece160e13adff4085) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31619509)</sub>

<!-- /greptile_comment -->