### PR TITLE
docs: fix RefreshCookieName described as optional in README quick-start examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ authHandler := &handler.AuthHandler{
     SecureCookies:     true,
     Sessions:          sessionStore,      // enables server-side sessions + refresh tokens
     RefreshTokenTTL:   7 * 24 * time.Hour,
-    RefreshCookieName: "refresh",         // optional: deliver refresh token via cookie
+    RefreshCookieName: "refresh",         // required when Sessions is set
 }
 apiKeyHandler := &handler.APIKeyHandler{
     APIKeys:      apiKeyStore,
@@ -517,7 +517,7 @@ h := &handler.AuthHandler{
     DisableSignup:     false,    // set true to prevent self-registration
     Sessions:          sessionStore, // optional; enables session tracking and refresh tokens
     RefreshTokenTTL:   handler.DefaultRefreshTokenTTL, // 7-day default (handler.DefaultRefreshTokenTTL); only used when Sessions is set
-    RefreshCookieName: "refresh",  // optional; stores refresh token in an HttpOnly cookie
+    RefreshCookieName: "refresh",  // required when Sessions is set; stores refresh token in an HttpOnly cookie
     RequireVerification: true,     // optional; rejects login for unverified email addresses
 }
 


### PR DESCRIPTION
…rt examples

RefreshCookieName is required (not optional) when Sessions is set on AuthHandler. AuthHandler.Validate() enforces this constraint and returns an error if Sessions is non-nil but RefreshCookieName is empty.

Update two code snippet comments in README.md to say 'required when Sessions is set' instead of the previous misleading 'optional' wording, consistent with docs/handler/auth.md and the Validate() documentation.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes misleading inline code comments in `README.md` that described `RefreshCookieName` as optional, when `AuthHandler.Validate()` in `handler/auth.go` actually returns an error if `Sessions` is non-nil and `RefreshCookieName` is empty.

- Two snippet comments are updated from "optional" to "required when Sessions is set", bringing `README.md` into alignment with both `docs/handler/auth.md` and the `Validate()` godoc.
- No code changes are included; this is a documentation-only fix.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no code modifications; safe to merge.

Both updated comments now accurately reflect the behavior enforced by AuthHandler.Validate() in handler/auth.go — Sessions non-nil with an empty RefreshCookieName returns an error. The fix is factually correct and consistent with the existing docs and godoc.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Two inline comments updated to correctly describe RefreshCookieName as required when Sessions is set, matching the actual Validate() enforcement in handler/auth.go |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AuthHandler.Validate called] --> B{Sessions != nil?}
    B -- No --> C[Return nil - OK]
    B -- Yes --> D{RefreshCookieName == empty?}
    D -- No --> E[Return nil - OK]
    D -- Yes --> F[Return error: Sessions requires RefreshCookieName]
    F --> G[Server startup fails - misconfiguration caught early]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix RefreshCookieName described as..."](https://github.com/amalgamated-tools/goauth/commit/1792b5ad77b83435d0b616da0c7c07dcd77ff0c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31632329)</sub>

<!-- /greptile_comment -->