### PR TITLE
feat: add GitHub Actions workflow for Release Please automation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,23 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    # Release Please should complete in well under 10 minutes.
+    # Without a timeout, a hung runner would default to 6 hours.
+    timeout-minutes: 10
+    steps:
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a GitHub Actions workflow for Release Please automation, triggered on pushes to `main` with appropriately scoped permissions and a SHA-pinned action reference.

- The workflow is correctly structured with a 10-minute timeout, `contents`/`issues`/`pull-requests: write` permissions, and a pinned action SHA — but it references `release-please-config.json` and `.release-please-manifest.json`, neither of which exists in the repository. The workflow will fail on its first run.
- `googleapis/release-please-action` is not recorded in `.github/aw/actions-lock.json`, which the repo uses to track all third-party action SHAs.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The workflow will error on its first run because both config files it depends on don't exist yet; merging without them leaves the automation non-functional from day one.

The action SHA is correctly pinned and permissions are appropriately scoped, but the workflow cannot succeed until `release-please-config.json` and `.release-please-manifest.json` are added to the repo. Every push to main after merging will trigger a failing workflow run until those files land.

.github/workflows/release-please.yml — depends on two config files that are absent from the repository
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-please.yml | Adds Release Please automation workflow pinned to a SHA; will fail at runtime because both referenced config files (release-please-config.json and .release-please-manifest.json) are absent from the repo |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub (push to main)
    participant WF as release-please workflow
    participant RP as release-please-action
    participant CF as release-please-config.json
    participant API as GitHub API

    GH->>WF: push event on main
    WF->>RP: "run googleapis/release-please-action@SHA"
    RP->>CF: read config-file
    CF-->>RP: file not found (missing)
    RP-->>WF: error / failure
    note over WF,API: Workflow fails before creating release PR or tag
```
</details>

<a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amalgamated-tools%2Fgoauth%22%20on%20the%20existing%20branch%20%22release-please%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22release-please%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Frelease-please.yml%3A22-23%0A**Referenced%20config%20files%20are%20missing%20from%20the%20repository**%0A%0ABoth%20%60release-please-config.json%60%20and%20%60.release-please-manifest.json%60%20are%20specified%20here%20but%20neither%20file%20exists%20in%20the%20repository.%20When%20this%20workflow%20triggers%20on%20the%20next%20push%20to%20%60main%60%2C%20Release%20Please%20will%20attempt%20to%20load%20these%20files%2C%20fail%20to%20find%20them%2C%20and%20the%20run%20will%20error%20out%20before%20creating%20any%20release%20PR%20or%20tag.%20These%20files%20need%20to%20be%20created%20alongside%20this%20workflow%20for%20it%20to%20function%20at%20all.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease-please.yml%3A19%0A**Action%20SHA%20not%20recorded%20in%20%60actions-lock.json%60**%0A%0AThe%20repository%20maintains%20%60.github%2Faw%2Factions-lock.json%60%20to%20track%20pinned%20SHAs%20for%20all%20third-party%20actions%20%28e.g.%2C%20%60actions%2Fcache%60%2C%20%60actions%2Fcheckout%60%29.%20%60googleapis%2Frelease-please-action%4045996ed...%60%20is%20not%20present%20in%20that%20lock%20file%2C%20breaking%20the%20established%20pattern.%20The%20SHA%20should%20be%20added%20to%20the%20lock%20file%20to%20keep%20the%20inventory%20consistent%20and%20make%20future%20audits%20easier.%0A%0A&repo=amalgamated-tools%2Fgoauth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/release-please.yml:22-23
**Referenced config files are missing from the repository**

Both `release-please-config.json` and `.release-please-manifest.json` are specified here but neither file exists in the repository. When this workflow triggers on the next push to `main`, Release Please will attempt to load these files, fail to find them, and the run will error out before creating any release PR or tag. These files need to be created alongside this workflow for it to function at all.

### Issue 2 of 2
.github/workflows/release-please.yml:19
**Action SHA not recorded in `actions-lock.json`**

The repository maintains `.github/aw/actions-lock.json` to track pinned SHAs for all third-party actions (e.g., `actions/cache`, `actions/checkout`). `googleapis/release-please-action@45996ed...` is not present in that lock file, breaking the established pattern. The SHA should be added to the lock file to keep the inventory consistent and make future audits easier.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add GitHub Actions workflow for Re..."](https://github.com/amalgamated-tools/goauth/commit/6d101e76aa38a7c576dbaaeaa92193f7b5639898) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33622735)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->