### PR TITLE
docs: document release process and Conventional Commits requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thank you for considering a contribution to goauth! This guide covers everything
 - [Full pre-PR check](#full-pre-pr-check)
 - [Coding conventions](#coding-conventions)
 - [Submitting changes](#submitting-changes)
+- [Release process](#release-process)
 
 ---
 
@@ -132,3 +133,52 @@ All changes must go through a pull request. The `main` branch is protected.
 4. Ensure the CI checks (lint, format, tests) pass on your PR.
 
 For significant API changes or new features, open an issue first to discuss the design before investing time in an implementation.
+
+---
+
+## Release process
+
+goauth uses [Release Please](https://github.com/googleapis/release-please) to automate version bumps, changelog generation, and GitHub Releases. Releases are created automatically when pull requests are merged into `main`.
+
+### Conventional Commits
+
+All commits merged into `main` **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. Release Please parses commit messages to determine the next semantic version and to generate the `CHANGELOG.md`.
+
+| Commit type | When to use | Version bump |
+|---|---|---|
+| `feat: …` | A new feature visible to library consumers | Minor (`0.x.0`) |
+| `fix: …` | A bug fix | Patch (`0.0.x`) |
+| `docs: …` | Documentation-only changes | None |
+| `refactor: …` | Code change that is neither a fix nor a feature | None |
+| `test: …` | Adding or updating tests | None |
+| `chore: …` | Build process, dependency updates, tooling | None |
+| `feat!: …` or `BREAKING CHANGE:` footer | Backwards-incompatible change | Major (`x.0.0`) |
+
+**Examples:**
+
+```
+feat: add WebAuthn conditional-mediation support
+fix: prevent session cookie from being set on OIDC link errors
+docs: clarify RefreshCookieName requirement in PasskeyHandler
+feat!: remove deprecated LegacyAuth field from AuthHandler
+
+BREAKING CHANGE: LegacyAuth was removed; migrate to AuthHandler.Sessions.
+```
+
+### How releases work
+
+1. Every push to `main` triggers the Release Please GitHub Actions workflow.
+2. Release Please opens (or updates) a **Release PR** that bumps `go.mod` (if configured), updates `CHANGELOG.md`, and proposes the next version tag.
+3. Merging the Release PR creates a Git tag and a GitHub Release with the generated changelog.
+
+> **Note:** You do not need to manually create tags or edit `CHANGELOG.md`. Both are managed entirely by Release Please.
+
+### Commit message scope (optional)
+
+Add an optional scope in parentheses to clarify which package or area is affected:
+
+```
+feat(handler): add conditional-mediation option to PasskeyHandler
+fix(auth): correct TOTP window drift calculation
+```
+


### PR DESCRIPTION
Add a Release process section to CONTRIBUTING.md explaining:
- goauth uses Release Please for automated releases
- All commits to main must follow Conventional Commits spec
- Commit type table with corresponding version bumps
- Examples of valid commit messages including breaking changes
- How the release PR flow works
- Optional scope syntax

Triggered by the addition of the Release Please workflow in #358.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Release process" section to `CONTRIBUTING.md` documenting the Release Please automation introduced by #358, explaining Conventional Commits requirements, version bump semantics, and the Release PR flow.

- Adds a commit-type reference table mapping `feat:`, `fix:`, `chore:`, etc. to their corresponding semver bumps, along with breaking-change examples and optional scope syntax.
- The introductory sentence slightly overstates how releases are triggered (every merged PR vs. only the Release PR), and the combined breaking-change example block is ambiguous about whether the `BREAKING CHANGE:` footer belongs to a single commit or to all four listed examples.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no code impact; safe to merge after addressing the two clarity issues.

The new section is accurate overall, but the opening sentence misleadingly implies every merged PR creates a release (rather than just updating the Release PR), and the breaking-change example block could leave contributors unsure whether `BREAKING CHANGE:` is a footer for the final commit or a standalone item. Neither issue affects runtime behaviour, but incorrect understanding of the release flow could lead to contributors expecting releases that won't happen.

CONTRIBUTING.md — the introductory sentence (line 141) and the combined example block (lines 159–166) would benefit from the suggested clarifications.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Adds a "Release process" section covering Release Please automation, Conventional Commits table, release PR flow, and optional scope syntax; two minor clarity issues in the opening sentence and the breaking-change example block. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer opens PR] --> B[PR merged into main]
    B --> C[Release Please workflow triggered]
    C --> D{Release PR exists?}
    D -- No --> E[Release Please opens new Release PR\nbumps CHANGELOG.md + version tag]
    D -- Yes --> F[Release Please updates existing Release PR\nwith new commits]
    E --> G[Team reviews Release PR]
    F --> G
    G --> H[Release PR merged into main]
    H --> I[Git tag created]
    I --> J[GitHub Release published\nwith generated changelog]
```
</details>

<a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amalgamated-tools%2Fgoauth%22%20on%20the%20existing%20branch%20%22docs%2Frelease-process-contributing-b9f358ffcb86c496%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Frelease-process-contributing-b9f358ffcb86c496%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0ACONTRIBUTING.md%3A141%0AThe%20opening%20sentence%20implies%20that%20every%20PR%20merged%20to%20%60main%60%20creates%20a%20release%2C%20but%20that's%20not%20how%20Release%20Please%20works.%20Merging%20a%20regular%20PR%20only%20causes%20Release%20Please%20to%20open%20or%20update%20a%20Release%20PR%20%E2%80%94%20the%20actual%20release%20%28tag%20%2B%20GitHub%20Release%29%20is%20only%20created%20when%20*that%20Release%20PR*%20is%20merged.%20A%20first-time%20contributor%20reading%20only%20this%20sentence%20could%20be%20confused%20when%20their%20feature%20PR%20doesn't%20produce%20a%20release.%0A%0A%60%60%60suggestion%0Agoauth%20uses%20%5BRelease%20Please%5D%28https%3A%2F%2Fgithub.com%2Fgoogleapis%2Frelease-please%29%20to%20automate%20version%20bumps%2C%20changelog%20generation%2C%20and%20GitHub%20Releases.%20When%20a%20pull%20request%20is%20merged%20into%20%60main%60%2C%20Release%20Please%20opens%20or%20updates%20a%20**Release%20PR**%3B%20merging%20that%20Release%20PR%20is%20what%20actually%20publishes%20a%20release.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0ACONTRIBUTING.md%3A159-166%0AThe%20combined%20example%20block%20is%20ambiguous%3A%20the%20%60BREAKING%20CHANGE%3A%60%20footer%20on%20the%20last%20line%20visually%20looks%20like%20either%20a%20fifth%20standalone%20commit%20or%20an%20annotation%20that%20applies%20to%20all%20four%20commit%20lines%20above%20it.%20In%20Conventional%20Commits%2C%20the%20footer%20must%20appear%20in%20its%20own%20commit%20and%20be%20separated%20from%20the%20subject%20by%20an%20optional%20body%20%E2%80%94%20not%20listed%20alongside%20unrelated%20commits.%20Splitting%20it%20into%20two%20clearly%20labelled%20examples%20removes%20the%20ambiguity.%0A%0A%60%60%60suggestion%0A%60%60%60%0Afeat%3A%20add%20WebAuthn%20conditional-mediation%20support%0Afix%3A%20prevent%20session%20cookie%20from%20being%20set%20on%20OIDC%20link%20errors%0Adocs%3A%20clarify%20RefreshCookieName%20requirement%20in%20PasskeyHandler%0A%60%60%60%0A%0ABreaking%20changes%20can%20be%20signalled%20with%20%60!%60%20after%20the%20type%2C%20or%20with%20a%20%60BREAKING%20CHANGE%3A%60%20footer%2C%20or%20both%3A%0A%0A%60%60%60%0Afeat!%3A%20remove%20deprecated%20LegacyAuth%20field%20from%20AuthHandler%0A%0ABREAKING%20CHANGE%3A%20LegacyAuth%20was%20removed%3B%20migrate%20to%20AuthHandler.Sessions.%0A%60%60%60%0A%60%60%60%0A%0A&repo=amalgamated-tools%2Fgoauth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
CONTRIBUTING.md:141
The opening sentence implies that every PR merged to `main` creates a release, but that's not how Release Please works. Merging a regular PR only causes Release Please to open or update a Release PR — the actual release (tag + GitHub Release) is only created when *that Release PR* is merged. A first-time contributor reading only this sentence could be confused when their feature PR doesn't produce a release.

```suggestion
goauth uses [Release Please](https://github.com/googleapis/release-please) to automate version bumps, changelog generation, and GitHub Releases. When a pull request is merged into `main`, Release Please opens or updates a **Release PR**; merging that Release PR is what actually publishes a release.
```

### Issue 2 of 2
CONTRIBUTING.md:159-166
The combined example block is ambiguous: the `BREAKING CHANGE:` footer on the last line visually looks like either a fifth standalone commit or an annotation that applies to all four commit lines above it. In Conventional Commits, the footer must appear in its own commit and be separated from the subject by an optional body — not listed alongside unrelated commits. Splitting it into two clearly labelled examples removes the ambiguity.

```suggestion
```
feat: add WebAuthn conditional-mediation support
fix: prevent session cookie from being set on OIDC link errors
docs: clarify RefreshCookieName requirement in PasskeyHandler
```

Breaking changes can be signalled with `!` after the type, or with a `BREAKING CHANGE:` footer, or both:

```
feat!: remove deprecated LegacyAuth field from AuthHandler

BREAKING CHANGE: LegacyAuth was removed; migrate to AuthHandler.Sessions.
```
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document release process and Conve..."](https://github.com/amalgamated-tools/goauth/commit/f88e8853402a5041d9c925299373a0a729f09991) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33663328)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->