### PR TITLE
[docs] Document code coverage collection and CI upload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for considering a contribution to goauth! This guide covers everything
 - [Prerequisites](#prerequisites)
 - [Getting started](#getting-started)
 - [Running tests](#running-tests)
+  - [Code coverage](#code-coverage)
 - [Linting and formatting](#linting-and-formatting)
 - [Full pre-PR check](#full-pre-pr-check)
 - [Coding conventions](#coding-conventions)
@@ -47,6 +48,20 @@ make testsum       # gotestsum -- -v ./...
 ```
 
 Tests cover every package (`auth`, `handler`, `smtp`, `maintenance`). Because `handler` tests use in-memory store implementations, **no external services are required** to run the full test suite.
+
+### Code coverage
+
+To generate a local coverage profile and inspect it:
+
+```sh
+go test -coverprofile=coverage.out ./...
+go tool cover -func=coverage.out   # per-function summary
+go tool cover -html=coverage.out   # open an annotated HTML report
+```
+
+In CI, the `go-test` job automatically converts `coverage.out` to Cobertura XML and uploads it to GitHub Code Quality under the label `code-coverage/go-test`. This gives pull requests a coverage delta and file-level breakdown in the review UI.
+
+The upload step runs only on non-fork PRs (and pushes to `main`). It is configured with `fail-on-error: false`, so a transient upload failure surfaces as a warning but never blocks a merge.
 
 ## Linting and formatting
 
@@ -130,7 +145,7 @@ All changes must go through a pull request. The `main` branch is protected.
    ```
 2. Make your changes, add tests, and run `make all` to verify everything passes.
 3. Open a pull request against `main` with a clear description of the problem and solution.
-4. Ensure the CI checks (lint, format, tests) pass on your PR.
+4. Ensure the CI checks (lint, format, tests, and coverage upload) pass on your PR. Coverage upload failures are non-blocking (warnings only), but lint and test failures will block the merge.
 
 For significant API changes or new features, open an issue first to discuss the design before investing time in an implementation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Tests cover every package (`auth`, `handler`, `smtp`, `maintenance`). Because `h
 To generate a local coverage profile and inspect it:
 
 ```sh
-go test -coverprofile=coverage.out ./...
+go test -coverprofile=coverage.out -covermode=atomic ./...
 go tool cover -func=coverage.out   # per-function summary
 go tool cover -html=coverage.out   # open an annotated HTML report
 ```
@@ -145,7 +145,7 @@ All changes must go through a pull request. The `main` branch is protected.
    ```
 2. Make your changes, add tests, and run `make all` to verify everything passes.
 3. Open a pull request against `main` with a clear description of the problem and solution.
-4. Ensure the CI checks (lint, format, tests, and coverage upload) pass on your PR. Coverage upload failures are non-blocking (warnings only), but lint and test failures will block the merge.
+4. Ensure the CI checks (lint, format, and tests) pass on your PR — these are required for merge. The coverage upload runs automatically on non-fork PRs; failures surface as warnings and never block the merge.
 
 For significant API changes or new features, open an issue first to discuss the design before investing time in an implementation.
 


### PR DESCRIPTION
Add a 'Code coverage' subsection under 'Running tests' in CONTRIBUTING.md
explaining:
- How to generate a local coverage profile and view it locally
- How CI converts coverage.out to Cobertura XML via gocover-cobertura
- The GitHub Code Quality upload under label code-coverage/go-test
- The fail-on-error: false behavior (warnings, never blocking)
- The fork-safe upload condition

Also updates the 'Submitting changes' checklist to mention coverage upload.

Closes #402
Closes #429
Closes #434 

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Code coverage" subsection to `CONTRIBUTING.md` explaining how to generate a local coverage profile and how CI collects, converts, and uploads coverage data to GitHub Code Quality. It also updates step 4 of the "Submitting changes" checklist to clarify which checks are required for merge vs. advisory-only.

- Adds local coverage commands (`go test -coverprofile`, `go tool cover`) and explains the CI pipeline: `go-test` job converts `coverage.out` to Cobertura XML via `gocover-cobertura` and uploads under the `code-coverage/go-test` label with `fail-on-error: false`.
- Updates the checklist to explicitly distinguish blocking CI checks from the non-blocking coverage upload, clarifying the fork-safe upload condition.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely documentation with no logic changes.

Every factual claim in the new Code coverage section was cross-checked against .github/workflows/test.yml: the job name (go-test), the gocover-cobertura conversion step, the code-coverage/go-test label, the fail-on-error: false flag, and the fork-safe upload condition all match the workflow exactly. The checklist update accurately describes blocking vs. non-blocking behaviour.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Documentation-only change; all factual claims (job name, label, fail-on-error flag, fork condition) verified against .github/workflows/test.yml — no inaccuracies found. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["go test -coverprofile=coverage.out -covermode=atomic ./..."] --> B["gocover-cobertura < coverage.out > coverage.xml"]
    B --> C["Display coverage summary\n(go tool cover -func)"]
    C --> D{Non-fork PR or\npush to main?}
    D -->|Yes| E["actions/upload-code-coverage\nlabel: code-coverage/go-test\nfail-on-error: false"]
    D -->|No| F["Skip upload\n(fork PR)"]
    E --> G["Coverage delta + file breakdown\nin GitHub Code Quality UI"]
    E -->|Transient failure| H["Surfaces as warning\nMerge not blocked"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Apply suggestions from code review"](https://github.com/amalgamated-tools/goauth/commit/0fe2c347f0888fb5b5b92cd47a49b9b8080ece43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35452037)</sub>

<!-- /greptile_comment -->