### PR TITLE
docs: document listUserResources and deleteUserResource helpers in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,9 @@ The `handler` package uses `*_common.go` files to hold logic shared by multiple 
 - `requireField`: shared `Validate` helper for required dependency checks.
 - `validateSessionConfig`: shared `Validate` helper for session/refresh-cookie configuration.
 - `logOrDefault`: returns the configured logger, falling back to `slog.Default()`.
+- `deleteUserResource`: shared DELETE helper — validates the resource ID from the URL, calls the store's delete function, and handles not-found, store-error, and 204 No Content responses. Used by `APIKeyHandler.Delete`, `SessionHandler.Revoke`, and `PasskeyHandler.DeleteCredential`.
 - `issueTokens`: issues access/refresh tokens, writes auth cookies, and manages session-backed refresh tokens.
+- `listUserResources`: generic (type-parameterized) list helper — fetches resources for the current user, converts each item to a DTO via a caller-supplied function, and writes the JSON response. Accepts separate log and user-facing error messages to avoid leaking internal context to clients. Used by `APIKeyHandler.List`, `SessionHandler.List`, and `PasskeyHandler.ListCredentials`.
 - `writeJSON`: shared JSON response writer.
 - `writeError`: shared JSON error response writer.
 - `setNoCacheHeaders`: applies no-cache headers to sensitive auth responses.


### PR DESCRIPTION
The refactor in #492 extracted two generic helpers into helpers.go but
they were not added to the CONTRIBUTING.md inventory. Add entries for:

- deleteUserResource: shared DELETE endpoint helper (APIKeyHandler.Delete,
  SessionHandler.Revoke, PasskeyHandler.DeleteCredential)
- listUserResources: generic list-to-DTO helper (APIKeyHandler.List,
  SessionHandler.List, PasskeyHandler.ListCredentials)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds CONTRIBUTING.md inventory entries for two generic HTTP handler helpers (`deleteUserResource` and `listUserResources`) that were extracted into `helpers.go` during the #492 refactor but were missing from the documentation.

- `deleteUserResource` entry accurately describes parameter extraction via `paramFunc`, the not-found/store-error/204 response branches, and the three calling handlers.
- `listUserResources` entry correctly notes the type-parameterized signature, the DTO conversion callback, the split log/user-facing error messages, and the three calling handlers.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; no executable code is modified.

The two added descriptions accurately reflect the actual implementations in helpers.go — the control-flow branches, generic type parameters, callback signatures, and caller lists all match the source. No code paths are touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Two helper entries added to the helpers.go inventory; descriptions accurately match the source implementations in helpers.go. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph deleteUserResource
        A[HTTP DELETE request] --> B{paramFunc extracts id}
        B -- empty --> C[400 Bad Request]
        B -- non-empty --> D[del ctx id userID]
        D -- ErrNotFound --> E[404 Not Found]
        D -- other error --> F[500 Internal Server Error + log via logOrDefault]
        D -- success --> G[204 No Content]
    end

    subgraph listUserResources
        H[HTTP GET request] --> I[fetch ctx userID]
        I -- error --> J[500 Internal Server Error + log via logOrDefault]
        I -- success --> K[toDTO each item]
        K --> L[200 OK JSON array]
    end

    M[APIKeyHandler.Delete] --> deleteUserResource
    N[SessionHandler.Revoke] --> deleteUserResource
    O[PasskeyHandler.DeleteCredential] --> deleteUserResource

    P[APIKeyHandler.List] --> listUserResources
    Q[SessionHandler.List] --> listUserResources
    R[PasskeyHandler.ListCredentials] --> listUserResources
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document listUserResources and del..."](https://github.com/amalgamated-tools/goauth/commit/b175606d3a4b1d7a76fb2f1419036b5daac4e075) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36561337)</sub>

<!-- /greptile_comment -->